### PR TITLE
feat: send metrics to NR only when installed as NPM binary

### DIFF
--- a/bin/run_bin
+++ b/bin/run_bin
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-process.env.NODE_ENV = 'development';
+// Only the binary installed through NPM is considered production environment. See "bin" in package.json.
+process.env.NODE_ENV = 'production';
 
 const oclif = require('@oclif/core');
 

--- a/bin/run_bin.cmd
+++ b/bin/run_bin.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\run_bin" %*

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@oclif/core": "^1.26.2",
         "@oclif/errors": "^1.3.6",
         "@oclif/plugin-not-found": "^2.3.22",
-        "@smoya/asyncapi-adoption-metrics": "^1.1.1",
+        "@smoya/asyncapi-adoption-metrics": "^2.0.0",
         "@smoya/multi-parser": "^4.0.0",
         "@stoplight/spectral-cli": "6.9.0",
         "ajv": "^8.12.0",
@@ -48,7 +48,7 @@
         "ws": "^8.2.3"
       },
       "bin": {
-        "asyncapi": "bin/run"
+        "asyncapi": "bin/run_bin"
       },
       "devDependencies": {
         "@asyncapi/minimaltemplate": "./test/fixtures/minimaltemplate",
@@ -5563,9 +5563,9 @@
       }
     },
     "node_modules/@smoya/asyncapi-adoption-metrics": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smoya/asyncapi-adoption-metrics/-/asyncapi-adoption-metrics-1.1.1.tgz",
-      "integrity": "sha512-1UTfJsw3+iUSaROu03s6OXA32HkM+h9kT1P1gZCOCddRybL5PJzvP/X3FIJEM9IICu1B7btVXdy3VNIZ/9LCaw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smoya/asyncapi-adoption-metrics/-/asyncapi-adoption-metrics-2.0.0.tgz",
+      "integrity": "sha512-rux64DUwdBak8PIRUHFhsoRmDU+55WYZcoHmYCOpSBrlP5JPgcMDo2xRp3dLUBo/XN6F5Qkib0nAIkzdQGsSHg==",
       "dependencies": {
         "@smoya/multi-parser": "^4.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.1",
   "author": "@asyncapi",
   "bin": {
-    "asyncapi": "./bin/run"
+    "asyncapi": "./bin/run_bin"
   },
   "bugs": "https://github.com/asyncapi/cli/issues",
   "dependencies": {
@@ -23,7 +23,7 @@
     "@oclif/core": "^1.26.2",
     "@oclif/errors": "^1.3.6",
     "@oclif/plugin-not-found": "^2.3.22",
-    "@smoya/asyncapi-adoption-metrics": "^1.1.1",
+    "@smoya/asyncapi-adoption-metrics": "^2.0.0",
     "@smoya/multi-parser": "^4.0.0",
     "@stoplight/spectral-cli": "6.9.0",
     "ajv": "^8.12.0",

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,8 +1,14 @@
 import { Command } from '@oclif/core';
-import { Recorder, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
+import { NewRelicSink, Recorder, Sink, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
+
+class DiscardSink implements Sink {
+  async send() {
+    // noop
+  }
+}
 
 export default abstract class extends Command {
-  recorder = new Recorder('asyncapi-adoption', new StdOutSink());
+  recorder = recorderFromEnv('asyncapi_adoption');
 
   async catch(err: Error & { exitCode?: number; }): Promise<any> {
     try {
@@ -14,4 +20,25 @@ export default abstract class extends Command {
       }
     }
   }
+}
+
+function recorderFromEnv(prefix: string): Recorder {
+  let sink: Sink = new DiscardSink();
+  if (process.env.ASYNCAPI_METRICS !== 'false') {
+    switch (process.env.NODE_ENV) {
+    case 'development':
+      // NODE_ENV set to `development` in bin/run
+      if (!process.env.TEST) {
+        // Do not pollute stdout when running tests
+        sink = new StdOutSink();
+      }
+      break;
+    case 'production':
+      // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
+      sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
+      break;
+    }
+  }
+
+  return new Recorder(prefix, sink);
 }

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -87,7 +87,7 @@ export default class Bundle extends Command {
         const metadata = MetadataFromDocument(document);
         metadata['success'] = true;
         metadata['files'] = AsyncAPIFiles.length;
-        await this.recorder.recordActionExecution('bundle', metadata);
+        await this.recorder.recordActionExecuted('bundle', metadata);
         await this.recorder.flush();
       }
     } catch (e: any) {

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -82,8 +82,7 @@ export default class Convert extends Command {
         metadata['success'] = true;
         metadata['from_version'] = document.version();
         metadata['to_version'] = flags['target-version'];
-        console.log(metadata);
-        await this.recorder.recordActionExecution('convert', metadata);
+        await this.recorder.recordActionExecuted('convert', metadata);
         await this.recorder.flush();
       }
     } catch (e: any) {

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -154,7 +154,7 @@ export default class Template extends Command {
         const metadata = MetadataFromDocument(document);
         metadata['success'] = true;
         metadata['template'] = template;
-        await this.recorder.recordActionExecution('generate_fromTemplate', metadata);
+        await this.recorder.recordActionExecuted('generate_fromTemplate', metadata);
         await this.recorder.flush();
       }
     } catch (e: any) {

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -104,7 +104,7 @@ export default class Optimize extends Command {
 
       const specPath = specFile.getFilePath();
       let newPath = '';
-      
+
       if (specPath) {
         const pos = specPath.lastIndexOf('.');
         newPath = `${specPath.substring(0,pos) }_optimized.${ specPath.substring(pos+1)}`;
@@ -137,7 +137,7 @@ export default class Optimize extends Command {
         const metadata = MetadataFromDocument(document);
         metadata['success'] = true;
         metadata['optimizations'] = this.optimizations;
-        await this.recorder.recordActionExecution('optimize', metadata);
+        await this.recorder.recordActionExecuted('optimize', metadata);
         await this.recorder.flush();
       }
     } catch (e: any) {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -42,7 +42,7 @@ export default class Validate extends Command {
         const metadata = MetadataFromDocument(document);
         metadata['success'] = true;
         metadata['validation_result'] = result;
-        await this.recorder.recordActionExecution('validate', metadata);
+        await this.recorder.recordActionExecuted('validate', metadata);
         await this.recorder.flush();
       }
     } catch (e: any) {


### PR DESCRIPTION
**Description**

This PR enables the New Relic sink only when the CLI runs as binary installed by NPM (`npm install -g @asyncapi/cli`). Otherwise, metrics are just printed to stdout (Through the StdOut sink).
In order to do that, I created a new file in `bin` directory called `bin/run_bin` which is the one the binary will call. It is not specified in the `bin` section of the `package.json`.

This PR also updates the `@smoya/asyncapi-adoption-metrics` dependency to latest and adapts the code to latest renamings in such library.

cc @peter-rr 