### PR TITLE
Unify logic for metrics collection when any command is invoked

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -1,8 +1,6 @@
 import { Command } from '@oclif/core';
 import { MetadataFromDocument, MetricMetadata, NewRelicSink, Recorder, Sink, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
 import { Parser } from '@asyncapi/parser';
-import validate from '@asyncapi/parser';
-import template from 'lodash.template';
 
 class DiscardSink implements Sink {
   async send() {
@@ -31,28 +29,6 @@ export default abstract class extends Command {
         const {document} = await this.parser.parse(rawDocument);
         if (document !== undefined) {
           metadata = MetadataFromDocument(document, metadata);
-          const commandName : string = this.id || '';
-          switch (commandName) {
-          case 'validate':
-            metadata['success'] = true;
-            metadata['validation_result'] = await validate(this, specFile, flags);
-            break;
-          case 'convert':
-            metadata['from_version'] = document.version();
-            break;
-          case 'bundle':
-            metadata['success'] = true;
-            metadata['files'] = AsyncAPIFiles.length;
-            break;
-          case 'template':
-            metadata['success'] = true;
-            metadata['template'] = template;
-            break;
-          case 'optimize':
-            metadata['success'] = true;
-            metadata['optimizations'] = this.optimizations;
-            break;
-          }
         }
       } catch (e: any) {
         if (e instanceof Error) {

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,8 @@
 import { Command } from '@oclif/core';
 import { MetadataFromDocument, MetricMetadata, NewRelicSink, Recorder, Sink, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
 import { Parser } from '@asyncapi/parser';
+import validate from '@asyncapi/parser';
+import template from 'lodash.template';
 
 class DiscardSink implements Sink {
   async send() {
@@ -29,6 +31,28 @@ export default abstract class extends Command {
         const {document} = await this.parser.parse(rawDocument);
         if (document !== undefined) {
           metadata = MetadataFromDocument(document, metadata);
+          const commandName : string = this.id || '';
+          switch (commandName) {
+          case 'validate':
+            metadata['success'] = true;
+            metadata['validation_result'] = await validate(this, specFile, flags);
+            break;
+          case 'convert':
+            metadata['from_version'] = document.version();
+            break;
+          case 'bundle':
+            metadata['success'] = true;
+            metadata['files'] = AsyncAPIFiles.length;
+            break;
+          case 'template':
+            metadata['success'] = true;
+            metadata['template'] = template;
+            break;
+          case 'optimize':
+            metadata['success'] = true;
+            metadata['optimizations'] = this.optimizations;
+            break;
+          }
         }
       } catch (e: any) {
         if (e instanceof Error) {

--- a/src/base.ts
+++ b/src/base.ts
@@ -2,16 +2,6 @@ import { Command } from '@oclif/core';
 import { MetadataFromDocument, MetricMetadata, NewRelicSink, Recorder, Sink, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
 import { Parser } from '@asyncapi/parser';
 
-/* export type Flags<T extends typeof Command> = Interfaces.InferredFlags<typeof BaseCommand['baseFlags'] & T['flags']>
-export type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>
-
-export interface CommandInterface extends Command.Class {
-  configurationVariablesSection?: HelpSection;
-  envVariablesSection?: HelpSection;
-  errorCodes?: HelpSection;
-}
- */
-
 class DiscardSink implements Sink {
   async send() {
     // noop

--- a/src/base.ts
+++ b/src/base.ts
@@ -2,6 +2,16 @@ import { Command } from '@oclif/core';
 import { MetadataFromDocument, MetricMetadata, NewRelicSink, Recorder, Sink, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
 import { Parser } from '@asyncapi/parser';
 
+/* export type Flags<T extends typeof Command> = Interfaces.InferredFlags<typeof BaseCommand['baseFlags'] & T['flags']>
+export type Args<T extends typeof Command> = Interfaces.InferredArgs<T['args']>
+
+export interface CommandInterface extends Command.Class {
+  configurationVariablesSection?: HelpSection;
+  envVariablesSection?: HelpSection;
+  errorCodes?: HelpSection;
+}
+ */
+
 class DiscardSink implements Sink {
   async send() {
     // noop
@@ -62,6 +72,11 @@ export default abstract class extends Command {
       }
     }
   }
+
+  public async init(): Promise<void> {
+    await super.init();
+    await this.recordActionInvoked(Command.id);
+  }
 }
 
 function recorderFromEnv(prefix: string): Recorder {
@@ -77,7 +92,7 @@ function recorderFromEnv(prefix: string): Recorder {
       break;
     case 'production':
       // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
-      sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
+      sink = new NewRelicSink('eu01xxcdd37dabf88558212c92c3199aFFFFNRAL');
       break;
     }
   }

--- a/src/base.ts
+++ b/src/base.ts
@@ -82,7 +82,7 @@ function recorderFromEnv(prefix: string): Recorder {
       break;
     case 'production':
       // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
-      sink = new NewRelicSink('eu01xxcdd37dabf88558212c92c3199aFFFFNRAL');
+      sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
       break;
     }
   }

--- a/src/base.ts
+++ b/src/base.ts
@@ -63,9 +63,10 @@ export default abstract class extends Command {
     }
   }
 
-  public async init(): Promise<void> {
+  async init(): Promise<void> {
     await super.init();
-    await this.recordActionInvoked(Command.id);
+    const commandName : string = this.id || '';
+    await this.recordActionInvoked(commandName);
   }
 }
 

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -31,9 +31,6 @@ export default class Bundle extends Command {
   parser = new Parser();
 
   async run() {
-    // Metrics recording when command is invoked
-    await this.recordActionInvoked('bundle');
-
     const { argv, flags } = await this.parse(Bundle);
     const output = flags.output;
     let baseFile;

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -80,8 +80,8 @@ export default class Bundle extends Command {
 
     const result = await load(output);
 
-    // // Metrics recording.
-    // await this.recordActionExecuted(result.text(), {success: true, files: AsyncAPIFiles.length});
+    // Metrics recording.
+    await this.recordActionExecuted(result.text(), {success: true, files: AsyncAPIFiles.length});
   }
 
   async loadFiles(filepaths: string[]): Promise<Specification[]> {

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -80,8 +80,8 @@ export default class Bundle extends Command {
 
     const result = await load(output);
 
-    // Metrics recording.
-    await this.recordActionExecuted(result.text(), {success: true, files: AsyncAPIFiles.length});
+    // // Metrics recording.
+    // await this.recordActionExecuted(result.text(), {success: true, files: AsyncAPIFiles.length});
   }
 
   async loadFiles(filepaths: string[]): Promise<Specification[]> {

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -29,9 +29,6 @@ export default class Convert extends Command {
   ];
 
   async run() {
-    // Metrics recording when command is invoked
-    await this.recordActionInvoked('convert');
-
     const { args, flags } = await this.parse(Convert);
     const filePath = args['spec-file'];
     let specFile;

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -85,6 +85,6 @@ export default class Convert extends Command {
       }
     }
 
-    await this.recordActionExecuted('convert', metadata);
+    // await this.recordActionExecuted('convert', metadata);
   }
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -85,6 +85,6 @@ export default class Convert extends Command {
       }
     }
 
-    // await this.recordActionExecuted('convert', metadata);
+    await this.recordActionExecuted('convert', metadata);
   }
 }

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -112,9 +112,6 @@ export default class Template extends Command {
   parser = new Parser();
 
   async run() {
-    // Metrics recording when command is invoked
-    await this.recordActionInvoked('generate_from_template');
-
     const { args, flags } = await this.parse(Template); // NOSONAR
 
     const asyncapi = args['asyncapi'];

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -147,8 +147,8 @@ export default class Template extends Command {
       await this.runWatchMode(asyncapi, template, output, watcherHandler);
     }
 
-    // Metrics recording.
-    await this.recordActionExecuted('generate_from_template', {success: true, template}, asyncapiInput.text());
+    // // Metrics recording.
+    // await this.recordActionExecuted('generate_from_template', {success: true, template}, asyncapiInput.text());
   }
 
   private parseFlags(disableHooks?: string[], params?: string[], mapBaseUrl?: string): ParsedFlags {

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -147,8 +147,8 @@ export default class Template extends Command {
       await this.runWatchMode(asyncapi, template, output, watcherHandler);
     }
 
-    // // Metrics recording.
-    // await this.recordActionExecuted('generate_from_template', {success: true, template}, asyncapiInput.text());
+    // Metrics recording.
+    await this.recordActionExecuted('generate_from_template', {success: true, template}, asyncapiInput.text());
   }
 
   private parseFlags(disableHooks?: string[], params?: string[], mapBaseUrl?: string): ParsedFlags {

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -50,9 +50,6 @@ export default class Optimize extends Command {
   parser = new Parser();
 
   async run() {
-    // Metrics recording when command is invoked
-    await this.recordActionInvoked('optimize');
-
     const { args, flags } = await this.parse(Optimize); //NOSONAR
     const filePath = args['spec-file'];
     let specFile: Specification;

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -129,8 +129,8 @@ export default class Optimize extends Command {
       });
     }
 
-    // // Metrics recording.
-    // await this.recordActionExecuted('optimize', {success: true, optimizations: this.optimizations}, specFile.text());
+    // Metrics recording.
+    await this.recordActionExecuted('optimize', {success: true, optimizations: this.optimizations}, specFile.text());
   }
 
   private showOptimizations(elements: ReportElement[] | undefined) {

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -129,8 +129,8 @@ export default class Optimize extends Command {
       });
     }
 
-    // Metrics recording.
-    await this.recordActionExecuted('optimize', {success: true, optimizations: this.optimizations}, specFile.text());
+    // // Metrics recording.
+    // await this.recordActionExecuted('optimize', {success: true, optimizations: this.optimizations}, specFile.text());
   }
 
   private showOptimizations(elements: ReportElement[] | undefined) {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -5,7 +5,6 @@ import { validate, validationFlags } from '../parser';
 import { load } from '../models/SpecificationFile';
 import { specWatcher } from '../globals';
 import { watchFlag } from '../flags';
-import { stringify } from 'querystring';
 
 export default class Validate extends Command {
   static description = 'validate asyncapi file';

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -29,9 +29,9 @@ export default class Validate extends Command {
       specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
     }
 
-    // const result = await validate(this, specFile, flags);
+    const result = await validate(this, specFile, flags);
 
-    // // Metrics recording.
-    // await this.recordActionExecuted('validate', {success: true, validation_result: result}, specFile.text());
+    // Metrics recording.
+    await this.recordActionExecuted('validate', {success: true, validation_result: result}, specFile.text());
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -5,6 +5,7 @@ import { validate, validationFlags } from '../parser';
 import { load } from '../models/SpecificationFile';
 import { specWatcher } from '../globals';
 import { watchFlag } from '../flags';
+import { stringify } from 'querystring';
 
 export default class Validate extends Command {
   static description = 'validate asyncapi file';
@@ -20,9 +21,6 @@ export default class Validate extends Command {
   ];
 
   async run() {
-    // Metrics recording when command is invoked
-    await this.recordActionInvoked('validate');
-
     const { args, flags } = await this.parse(Validate); //NOSONAR
     const filePath = args['spec-file'];
     const watchMode = flags.watch;

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -29,9 +29,9 @@ export default class Validate extends Command {
       specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
     }
 
-    const result = await validate(this, specFile, flags);
+    // const result = await validate(this, specFile, flags);
 
-    // Metrics recording.
-    await this.recordActionExecuted('validate', {success: true, validation_result: result}, specFile.text());
+    // // Metrics recording.
+    // await this.recordActionExecuted('validate', {success: true, validation_result: result}, specFile.text());
   }
 }


### PR DESCRIPTION
Add new methods to unify logic so metrics are collected when any CLI command is invoked. All this logic will be implemented in `base.ts` file and removed from the different command files.