### PR TITLE
feat: add message to warn users about metrics collection

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -9,7 +9,7 @@ class DiscardSink implements Sink {
 }
 
 export default abstract class extends Command {
-  recorder = recorderFromEnv('asyncapi_adoption');
+  recorder = this.recorderFromEnv('asyncapi_adoption');
   parser = new Parser();
 
   async catch(err: Error & { exitCode?: number; }): Promise<any> {
@@ -68,26 +68,27 @@ export default abstract class extends Command {
     const commandName : string = this.id || '';
     await this.recordActionInvoked(commandName);
   }
-}
 
-function recorderFromEnv(prefix: string): Recorder {
-  let sink: Sink = new DiscardSink();
-  if (process.env.ASYNCAPI_METRICS !== 'false') {
-    switch (process.env.NODE_ENV) {
-    case 'development':
-      // NODE_ENV set to `development` in bin/run
-      if (!process.env.TEST) {
-        // Do not pollute stdout when running tests
-        sink = new StdOutSink();
+  recorderFromEnv(prefix: string): Recorder {
+    let sink: Sink = new DiscardSink();
+    if (process.env.ASYNCAPI_METRICS !== 'false') {
+      switch (process.env.NODE_ENV) {
+      case 'development':
+        // NODE_ENV set to `development` in bin/run
+        if (!process.env.TEST) {
+          // Do not pollute stdout when running tests
+          sink = new StdOutSink();
+        }
+        break;
+      case 'production':
+        // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
+        sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
+        this.warn('AsyncAPI anonymously tracks command executions to improve the specification and tools, ensuring no sensitive data reaches our servers. It aids in comprehending how AsyncAPI tools are used and adopted, facilitating ongoing improvements to our specifications and tools.\n\nTo disable tracking, set the "ASYNCAPI_METRICS" env variable to "false" when executing the command. For instance:\n\nASYNCAPI_METRICS=false asyncapi validate spec_file.yaml');
+        break;
       }
-      break;
-    case 'production':
-      // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
-      sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
-      console.log('AsyncAPI anonymously tracks command executions to improve the specification and tools, ensuring no sensitive data reaches our servers.\nIt aids in comprehending how AsyncAPI tools are used and adopted, facilitating ongoing improvements to our specifications and tools.\n\nTo disable tracking, set the "ASYNCAPI_METRICS" env variable to "false" when executing the command. For instance:\n\nASYNCAPI_METRICS=false asyncapi validate spec_file.yaml');
-      break;
     }
+  
+    return new Recorder(prefix, sink);
   }
-
-  return new Recorder(prefix, sink);
 }
+

--- a/src/base.ts
+++ b/src/base.ts
@@ -84,7 +84,7 @@ function recorderFromEnv(prefix: string): Recorder {
     case 'production':
       // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
       sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
-      console.log('IMPORTANT MESSAGE: We are tracking metrics anonymously from the commands you are executing just for statistical purposes.');
+      console.log('AsyncAPI anonymously tracks command executions to improve the specification and tools, ensuring no sensitive data reaches our servers.\nIt aids in comprehending how AsyncAPI tools are used and adopted, facilitating ongoing improvements to our specifications and tools.\n\nTo disable tracking, set the "ASYNCAPI_METRICS" env variable to "false" when executing the command. For instance:\n\nASYNCAPI_METRICS=false asyncapi validate spec_file.yaml');
       break;
     }
   }

--- a/src/base.ts
+++ b/src/base.ts
@@ -84,6 +84,7 @@ function recorderFromEnv(prefix: string): Recorder {
     case 'production':
       // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
       sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
+      console.log('IMPORTANT MESSAGE: We are tracking metrics anonymously from the commands you are executing just for statistical purposes.');
       break;
     }
   }


### PR DESCRIPTION

**Description**
We are adding a message to warn users about metrics collection. This scenario will only take place when `NODE_ENV` variable is set to `production` in 'bin/run_bin', which is specified in 'bin' package.json section.