### PR TITLE
chore: unify logic for metrics collection when any command is executed

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -91,7 +91,7 @@ export default abstract class extends Command {
         break;
       case 'production':
         // NODE_ENV set to `production` in bin/run_bin, which is specified in 'bin' package.json section
-        sink = new NewRelicSink('eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
+        sink = new NewRelicSink(process.env.ASYNCAPI_METRICS_NEWRELIC_KEY || 'eu01xx73a8521047150dd9414f6aedd2FFFFNRAL');
         this.warn('AsyncAPI anonymously tracks command executions to improve the specification and tools, ensuring no sensitive data reaches our servers. It aids in comprehending how AsyncAPI tools are used and adopted, facilitating ongoing improvements to our specifications and tools.\n\nTo disable tracking, set the "ASYNCAPI_METRICS" env variable to "false" when executing the command. For instance:\n\nASYNCAPI_METRICS=false asyncapi validate spec_file.yaml');
         break;
       }

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,5 +1,5 @@
 import { Command } from '@oclif/core';
-import { MetadataFromDocument, MetricMetadata, NewRelicSink, Recorder, Sink, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
+import { MetricMetadata, NewRelicSink, Recorder, Sink, StdOutSink } from '@smoya/asyncapi-adoption-metrics';
 import { Parser } from '@asyncapi/parser';
 import { Specification } from 'models/SpecificationFile';
 

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -78,8 +78,14 @@ export default class Bundle extends Command {
     }
 
     // Metrics recording.
-    this.specFile = await load(output);
-    this.metricsMetadata = {files: AsyncAPIFiles.length};
+    try {
+      this.specFile = await load(output);
+      this.metricsMetadata = {files: AsyncAPIFiles.length};
+    } catch (e: any) {
+      if (e instanceof Error) {
+        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
+      }
+    }
   }
 
   async loadFiles(filepaths: string[]): Promise<Specification[]> {

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -79,7 +79,7 @@ export default class Bundle extends Command {
 
     // Metrics recording.
     this.specFile = await load(output);
-    this.metricsMetadata = {success: true, files: AsyncAPIFiles.length};
+    this.metricsMetadata = {files: AsyncAPIFiles.length};
   }
 
   async loadFiles(filepaths: string[]): Promise<Specification[]> {

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -6,6 +6,7 @@ import { promises } from 'fs';
 import path from 'path';
 import { Specification, load } from '../models/SpecificationFile';
 import { Parser } from '@asyncapi/parser';
+import { Document } from '@asyncapi/bundler/lib/document';
 
 const { writeFile } = promises;
 
@@ -36,6 +37,8 @@ export default class Bundle extends Command {
     const outputFormat = path.extname(argv[0]);
     const AsyncAPIFiles = await this.loadFiles(argv);
 
+    this.metricsMetadata.files = AsyncAPIFiles.length;
+
     const containsAsyncAPI3 = AsyncAPIFiles.filter((file) => {
       return file.isAsyncAPI3();
     });
@@ -53,6 +56,8 @@ export default class Bundle extends Command {
         base: baseFile
       }
     );
+    
+    await this.collectMetricsData(document);
 
     if (!output) {
       if (outputFormat === '.yaml' || outputFormat === '.yml') {
@@ -76,11 +81,12 @@ export default class Bundle extends Command {
       }
       this.log(`Check out your shiny new bundled files at ${output}`);
     }
+  }
 
-    // Metrics recording.
+  private async collectMetricsData(document: Document) {
     try {
-      this.specFile = await load(output);
-      this.metricsMetadata = {files: AsyncAPIFiles.length};
+      // We collect the metadata from the final output so it contains all the files
+      this.specFile = await load(new Specification(document.string()).text());
     } catch (e: any) {
       if (e instanceof Error) {
         this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -77,10 +77,9 @@ export default class Bundle extends Command {
       this.log(`Check out your shiny new bundled files at ${output}`);
     }
 
-    const result = await load(output);
-
     // Metrics recording.
-    await this.recordActionExecuted('bundle', {success: true, files: AsyncAPIFiles.length}, result.text());
+    this.specFile = await load(output);
+    this.metricsMetadata = {success: true, files: AsyncAPIFiles.length};
   }
 
   async loadFiles(filepaths: string[]): Promise<Specification[]> {

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -6,7 +6,6 @@ import { promises } from 'fs';
 import path from 'path';
 import { Specification, load } from '../models/SpecificationFile';
 import { Parser } from '@asyncapi/parser';
-import { MetadataFromDocument } from '@smoya/asyncapi-adoption-metrics';
 
 const { writeFile } = promises;
 
@@ -81,17 +80,7 @@ export default class Bundle extends Command {
     const result = await load(output);
 
     // Metrics recording.
-    this.metricsMetadata = {success: true, files: AsyncAPIFiles.length};
-    try {
-      const {document} = await this.parser.parse(result.text());
-      if (document !== undefined) {
-        this.metricsMetadata = MetadataFromDocument(document, this.metricsMetadata);
-      }
-    } catch (e: any) {
-      if (e instanceof Error) {
-        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
-      }
-    }
+    await this.recordActionExecuted('bundle', {success: true, files: AsyncAPIFiles.length}, result.text());
   }
 
   async loadFiles(filepaths: string[]): Promise<Specification[]> {

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -6,8 +6,6 @@ import { ValidationError } from '../errors/validation-error';
 import { load } from '../models/SpecificationFile';
 import { SpecificationFileNotFound } from '../errors/specification-file';
 import { convert } from '@asyncapi/converter';
-import { MetadataFromDocument, MetricMetadata } from '@smoya/asyncapi-adoption-metrics';
-
 import type { ConvertVersion } from '@asyncapi/converter';
 
 // @ts-ignore
@@ -31,21 +29,21 @@ export default class Convert extends Command {
   async run() {
     const { args, flags } = await this.parse(Convert);
     const filePath = args['spec-file'];
-    let specFile;
     let convertedFile;
     let convertedFileFormatted;
 
     try {
       // LOAD FILE
-      specFile = await load(filePath);
+      this.specFile = await load(filePath);
+      this.metricsMetadata.to_version = flags['target-version'];
 
       // CONVERSION
-      convertedFile = convert(specFile.text(), flags['target-version'] as ConvertVersion);
+      convertedFile = convert(this.specFile.text(), flags['target-version'] as ConvertVersion);
       if (convertedFile) {
-        if (specFile.getFilePath()) {
-          this.log(`File ${specFile.getFilePath()} successfully converted!`);
-        } else if (specFile.getFileURL()) {
-          this.log(`URL ${specFile.getFileURL()} successfully converted!`);
+        if (this.specFile.getFilePath()) {
+          this.log(`File ${this.specFile.getFilePath()} successfully converted!`);
+        } else if (this.specFile.getFileURL()) {
+          this.log(`URL ${this.specFile.getFileURL()} successfully converted!`);
         }
       }
 
@@ -68,22 +66,6 @@ export default class Convert extends Command {
         }));
       } else {
         this.error(err as Error);
-      }
-    }
-
-    // Metrics recording.
-    let metadata: MetricMetadata = {to_version: flags['target-version']};
-    try {
-      const {document} = await this.parser.parse(specFile.text());
-      if (document !== undefined) {
-        metadata = MetadataFromDocument(document, metadata);
-        metadata['from_version'] = document.version();
-        this.specFile = specFile;
-        this.metricsMetadata = metadata;
-      }
-    } catch (e: any) {
-      if (e instanceof Error) {
-        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
       }
     }
   }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -78,13 +78,13 @@ export default class Convert extends Command {
       if (document !== undefined) {
         metadata = MetadataFromDocument(document, metadata);
         metadata['from_version'] = document.version();
+        this.specFile = await load(filePath);
+        this.metricsMetadata = metadata;
       }
     } catch (e: any) {
       if (e instanceof Error) {
         this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
       }
     }
-
-    await this.recordActionExecuted('convert', metadata);
   }
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -6,7 +6,7 @@ import { ValidationError } from '../errors/validation-error';
 import { load } from '../models/SpecificationFile';
 import { SpecificationFileNotFound } from '../errors/specification-file';
 import { convert } from '@asyncapi/converter';
-import { MetadataFromDocument, MetricMetadata } from '@smoya/asyncapi-adoption-metrics';
+import { MetadataFromDocument } from '@smoya/asyncapi-adoption-metrics';
 
 import type { ConvertVersion } from '@asyncapi/converter';
 
@@ -72,19 +72,17 @@ export default class Convert extends Command {
     }
 
     // Metrics recording.
-    let metadata: MetricMetadata = {success: true, to_version: flags['target-version']};
+    this.metricsMetadata = {success: true, to_version: flags['target-version']};
     try {
       const {document} = await this.parser.parse(specFile.text());
       if (document !== undefined) {
-        metadata = MetadataFromDocument(document, metadata);
-        metadata['from_version'] = document.version();
+        this.metricsMetadata = MetadataFromDocument(document, this.metricsMetadata);
+        this.metricsMetadata['from_version'] = document.version();
       }
     } catch (e: any) {
       if (e instanceof Error) {
         this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
       }
     }
-
-    await this.recordActionExecuted('convert', metadata);
   }
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -78,7 +78,7 @@ export default class Convert extends Command {
       if (document !== undefined) {
         metadata = MetadataFromDocument(document, metadata);
         metadata['from_version'] = document.version();
-        this.specFile = await load(filePath);
+        this.specFile = specFile;
         this.metricsMetadata = metadata;
       }
     } catch (e: any) {

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -72,7 +72,7 @@ export default class Convert extends Command {
     }
 
     // Metrics recording.
-    let metadata: MetricMetadata = {success: true, to_version: flags['target-version']};
+    let metadata: MetricMetadata = {to_version: flags['target-version']};
     try {
       const {document} = await this.parser.parse(specFile.text());
       if (document !== undefined) {

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -146,7 +146,8 @@ export default class Template extends Command {
     }
 
     // Metrics recording.
-    await this.recordActionExecuted('generate_from_template', {success: true, template}, asyncapiInput.text());
+    this.specFile = asyncapiInput;
+    this.metricsMetadata = {success: true, template};
   }
 
   private parseFlags(disableHooks?: string[], params?: string[], mapBaseUrl?: string): ParsedFlags {

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -147,7 +147,7 @@ export default class Template extends Command {
 
     // Metrics recording.
     this.specFile = asyncapiInput;
-    this.metricsMetadata = {success: true, template};
+    this.metricsMetadata = {template};
   }
 
   private parseFlags(disableHooks?: string[], params?: string[], mapBaseUrl?: string): ParsedFlags {

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -12,6 +12,7 @@ import { isLocalTemplate, Watcher } from '../../utils/generator';
 import { ValidationError } from '../../errors/validation-error';
 import { GeneratorError } from '../../errors/generator-error';
 import { Parser } from '@asyncapi/parser';
+import { MetadataFromDocument } from '@smoya/asyncapi-adoption-metrics';
 
 import type { Example } from '@oclif/core/lib/interfaces';
 
@@ -147,7 +148,17 @@ export default class Template extends Command {
     }
 
     // Metrics recording.
-    await this.recordActionExecuted('generate_from_template', {success: true, template}, asyncapiInput.text());
+    this.metricsMetadata = {success: true, template};
+    try {
+      const {document} = await this.parser.parse(asyncapiInput.text());
+      if (document !== undefined) {
+        this.metricsMetadata = MetadataFromDocument(document, this.metricsMetadata);
+      }
+    } catch (e: any) {
+      if (e instanceof Error) {
+        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
+      }
+    }
   }
 
   private parseFlags(disableHooks?: string[], params?: string[], mapBaseUrl?: string): ParsedFlags {

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -126,6 +126,9 @@ export default class Template extends Command {
       disabledHooks: parsedFlags.disableHooks,
     };
     const asyncapiInput = (await load(asyncapi)) || (await load());
+    
+    this.specFile = asyncapiInput;
+    this.metricsMetadata.template = template;
 
     const watchTemplate = flags['watch'];
     const genOption: any = {};
@@ -144,10 +147,6 @@ export default class Template extends Command {
       const watcherHandler = this.watcherHandler(asyncapi, template, output, options, genOption);
       await this.runWatchMode(asyncapi, template, output, watcherHandler);
     }
-
-    // Metrics recording.
-    this.specFile = asyncapiInput;
-    this.metricsMetadata = {template};
   }
 
   private parseFlags(disableHooks?: string[], params?: string[], mapBaseUrl?: string): ParsedFlags {

--- a/src/commands/generate/fromTemplate.ts
+++ b/src/commands/generate/fromTemplate.ts
@@ -12,8 +12,6 @@ import { isLocalTemplate, Watcher } from '../../utils/generator';
 import { ValidationError } from '../../errors/validation-error';
 import { GeneratorError } from '../../errors/generator-error';
 import { Parser } from '@asyncapi/parser';
-import { MetadataFromDocument } from '@smoya/asyncapi-adoption-metrics';
-
 import type { Example } from '@oclif/core/lib/interfaces';
 
 const red = (text: string) => `\x1b[31m${text}\x1b[0m`;
@@ -148,17 +146,7 @@ export default class Template extends Command {
     }
 
     // Metrics recording.
-    this.metricsMetadata = {success: true, template};
-    try {
-      const {document} = await this.parser.parse(asyncapiInput.text());
-      if (document !== undefined) {
-        this.metricsMetadata = MetadataFromDocument(document, this.metricsMetadata);
-      }
-    } catch (e: any) {
-      if (e instanceof Error) {
-        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
-      }
-    }
+    await this.recordActionExecuted('generate_from_template', {success: true, template}, asyncapiInput.text());
   }
 
   private parseFlags(disableHooks?: string[], params?: string[], mapBaseUrl?: string): ParsedFlags {

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -129,7 +129,8 @@ export default class Optimize extends Command {
     }
 
     // Metrics recording.
-    await this.recordActionExecuted('optimize', {success: true, optimizations: this.optimizations}, specFile.text());
+    this.specFile = await load(filePath);
+    this.metricsMetadata = {success: true, optimizations: this.optimizations};
   }
 
   private showOptimizations(elements: ReportElement[] | undefined) {

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -8,7 +8,6 @@ import chalk from 'chalk';
 import { promises } from 'fs';
 import { Example } from '@oclif/core/lib/interfaces';
 import { Parser } from '@asyncapi/parser';
-import { MetadataFromDocument } from '@smoya/asyncapi-adoption-metrics';
 
 const { writeFile } = promises;
 
@@ -130,17 +129,7 @@ export default class Optimize extends Command {
     }
 
     // Metrics recording.
-    this.metricsMetadata = {success: true, optimizations: this.optimizations};
-    try {
-      const {document} = await this.parser.parse(specFile.text());
-      if (document !== undefined) {
-        this.metricsMetadata = MetadataFromDocument(document, this.metricsMetadata);
-      }
-    } catch (e: any) {
-      if (e instanceof Error) {
-        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
-      }
-    }
+    await this.recordActionExecuted('optimize', {success: true, optimizations: this.optimizations}, specFile.text());
   }
 
   private showOptimizations(elements: ReportElement[] | undefined) {

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -129,7 +129,7 @@ export default class Optimize extends Command {
     }
 
     // Metrics recording.
-    this.specFile = await load(filePath);
+    this.specFile = specFile;
     this.metricsMetadata = {optimizations: this.optimizations};
   }
 

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -130,7 +130,7 @@ export default class Optimize extends Command {
 
     // Metrics recording.
     this.specFile = await load(filePath);
-    this.metricsMetadata = {success: true, optimizations: this.optimizations};
+    this.metricsMetadata = {optimizations: this.optimizations};
   }
 
   private showOptimizations(elements: ReportElement[] | undefined) {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -32,6 +32,6 @@ export default class Validate extends Command {
 
     // Metrics recording.
     this.specFile = await load(filePath);
-    this.metricsMetadata = {success: true, validation_result: result};
+    this.metricsMetadata = {validation_result: result};
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -23,15 +23,13 @@ export default class Validate extends Command {
     const filePath = args['spec-file'];
     const watchMode = flags.watch;
 
-    const specFile = await load(filePath);
+    this.specFile = await load(filePath);
     if (watchMode) {
-      specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
+      specWatcher({ spec: this.specFile, handler: this, handlerName: 'validate' });
     }
 
-    const result = await validate(this, specFile, flags);
+    const result = await validate(this, this.specFile, flags);
 
-    // Metrics recording.
-    this.specFile = specFile;
-    this.metricsMetadata = {validation_result: result};
+    this.metricsMetadata.validation_result = result;
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,10 +1,10 @@
 import { Flags } from '@oclif/core';
+
 import Command from '../base';
 import { validate, validationFlags } from '../parser';
 import { load } from '../models/SpecificationFile';
 import { specWatcher } from '../globals';
 import { watchFlag } from '../flags';
-import { MetadataFromDocument } from '@smoya/asyncapi-adoption-metrics';
 
 export default class Validate extends Command {
   static description = 'validate asyncapi file';
@@ -32,16 +32,6 @@ export default class Validate extends Command {
     const result = await validate(this, specFile, flags);
 
     // Metrics recording.
-    this.metricsMetadata = {success: true, validation_result: result};
-    try {
-      const {document} = await this.parser.parse(specFile.text());
-      if (document !== undefined) {
-        this.metricsMetadata = MetadataFromDocument(document, this.metricsMetadata);
-      }
-    } catch (e: any) {
-      if (e instanceof Error) {
-        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
-      }
-    }
+    await this.recordActionExecuted('validate', {success: true, validation_result: result}, specFile.text());
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-
 import Command from '../base';
 import { validate, validationFlags } from '../parser';
 import { load } from '../models/SpecificationFile';
@@ -32,6 +31,7 @@ export default class Validate extends Command {
     const result = await validate(this, specFile, flags);
 
     // Metrics recording.
-    await this.recordActionExecuted('validate', {success: true, validation_result: result}, specFile.text());
+    this.specFile = await load(filePath);
+    this.metricsMetadata = {success: true, validation_result: result};
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -29,9 +29,8 @@ export default class Validate extends Command {
       specWatcher({ spec: specFile, handler: this, handlerName: 'validate' });
     }
 
-    const result = await validate(this, specFile, flags);
-
     // Metrics recording.
-    await this.recordActionExecuted('validate', {success: true, validation_result: result}, specFile.text());
+    const result = await validate(this, specFile, flags);
+    this.metricsMetadata = {success: true, validation_result: result};
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -31,7 +31,7 @@ export default class Validate extends Command {
     const result = await validate(this, specFile, flags);
 
     // Metrics recording.
-    this.specFile = await load(filePath);
+    this.specFile = specFile;
     this.metricsMetadata = {validation_result: result};
   }
 }


### PR DESCRIPTION
Add new methods to unify logic so metrics are collected when any CLI command is executed. All this logic will be implemented in base.ts file and removed from the different command files, except the metadata generated for every different command.
