### PR TITLE
feat: stop sending metrics when CLI command is executed on CI/CD pipeline

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -81,7 +81,7 @@ export default abstract class extends Command {
   recorderFromEnv(prefix: string): Recorder {
     let sink: Sink = new DiscardSink();
     
-    if (process.env.ASYNCAPI_METRICS !== 'false' && process.env.NODE_ENV !== 'CI') {
+    if (process.env.ASYNCAPI_METRICS !== 'false' && process.env.CI !== 'true') {
       switch (process.env.NODE_ENV) {
       case 'development':
         // NODE_ENV set to `development` in bin/run

--- a/src/base.ts
+++ b/src/base.ts
@@ -80,7 +80,8 @@ export default abstract class extends Command {
 
   recorderFromEnv(prefix: string): Recorder {
     let sink: Sink = new DiscardSink();
-    if (process.env.ASYNCAPI_METRICS !== 'false') {
+    
+    if (process.env.ASYNCAPI_METRICS !== 'false' && process.env.NODE_ENV !== 'CI') {
       switch (process.env.NODE_ENV) {
       case 'development':
         // NODE_ENV set to `development` in bin/run


### PR DESCRIPTION
**Description**
Stop sending metrics when `process.env.NODE_ENV === 'CI'`, which means that a CLI command is executed on CI/CD pipeline.