### PR TITLE
fix: solve `optimize` command issue when sending data to New Relic

### DIFF
--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -84,8 +84,9 @@ export default class Optimize extends Command {
     this.optimizations = flags.optimization as Optimizations[];
     this.outputMethod = flags.output as Outputs;
 
-    this.metricsMetadata.optimizations = this.optimizations;
-
+    const optimizationsObject = {...this.optimizations};
+    this.metricsMetadata.optimizations = optimizationsObject;
+    
     if (!(report.moveToComponents?.length || report.removeComponents?.length || report.reuseComponents?.length)) {
       this.log(`No optimization has been applied since ${this.specFile.getFilePath() ?? this.specFile.getFileURL()} looks optimized!`);
       return;

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -194,21 +194,12 @@ export default class Optimize extends Command {
       this.metricsMetadata.optimized = false;
     }
 
-    // for (const optimizationSelected of optimizationRes.optimization) {
-    //   if (optimizationSelected.length) {
-    //     this.metricsMetadata[`optimization_${optimizationSelected}`] = true;
-    //   }
-    // }
-
-    if (this.optimizations?.includes(Optimizations.MOVE_TO_COMPONENTS)) {
-      this.metricsMetadata.optimization_moveToComponents = true;
+    for (const optimizationSelected of optimizationRes.optimization) {
+      if (optimizationSelected.length) {
+        const toCamelCase = optimizationSelected.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (m: any, chr: string) => chr.toUpperCase());
+        this.metricsMetadata[`optimization_${toCamelCase}`] = true;
+      }
     }
-    if (this.optimizations?.includes(Optimizations.REMOVE_COMPONENTS)) {
-      this.metricsMetadata.optimization_removeComponents = true;
-    }
-    if (this.optimizations?.includes(Optimizations.REUSE_COMPONENTS)) {
-      this.metricsMetadata.optimization_reuseComponents = true;
-    }    
 
     const outputRes = await inquirer.prompt([{
       name: 'output',

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -84,10 +84,23 @@ export default class Optimize extends Command {
     this.optimizations = flags.optimization as Optimizations[];
     this.outputMethod = flags.output as Outputs;
 
-    this.metricsMetadata.optimizations = JSON.stringify(this.optimizations);
-    
     if (!(report.moveToComponents?.length || report.removeComponents?.length || report.reuseComponents?.length)) {
       this.log(`No optimization has been applied since ${this.specFile.getFilePath() ?? this.specFile.getFileURL()} looks optimized!`);
+      this.metricsMetadata.optimized = false;
+      return;
+    }
+  
+    if (report.moveToComponents?.length) {
+      this.metricsMetadata.optimization_moveToComponents = true;
+      this.metricsMetadata.optimized = true;
+    }
+    if (report.removeComponents?.length) {
+      this.metricsMetadata.optimization_removeComponents = true;
+      this.metricsMetadata.optimized = true;
+    }
+    if (report.reuseComponents?.length) {
+      this.metricsMetadata.optimization_reuseComponents = true;
+      this.metricsMetadata.optimized = true;
       return;
     }
 

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -84,26 +84,24 @@ export default class Optimize extends Command {
     this.optimizations = flags.optimization as Optimizations[];
     this.outputMethod = flags.output as Outputs;
 
+    this.metricsMetadata.optimized = true;
+
+    if (report.moveToComponents?.length) {
+      this.metricsMetadata.optimization_moveToComponents = true;
+    }
+    if (report.removeComponents?.length) {
+      this.metricsMetadata.optimization_removeComponents = true;
+    }
+    if (report.reuseComponents?.length) {
+      this.metricsMetadata.optimization_reuseComponents = true;
+    }
+
     if (!(report.moveToComponents?.length || report.removeComponents?.length || report.reuseComponents?.length)) {
       this.log(`No optimization has been applied since ${this.specFile.getFilePath() ?? this.specFile.getFileURL()} looks optimized!`);
       this.metricsMetadata.optimized = false;
       return;
     }
-  
-    if (report.moveToComponents?.length) {
-      this.metricsMetadata.optimization_moveToComponents = true;
-      this.metricsMetadata.optimized = true;
-    }
-    if (report.removeComponents?.length) {
-      this.metricsMetadata.optimization_removeComponents = true;
-      this.metricsMetadata.optimized = true;
-    }
-    if (report.reuseComponents?.length) {
-      this.metricsMetadata.optimization_reuseComponents = true;
-      this.metricsMetadata.optimized = true;
-      return;
-    }
-
+    
     const isTTY = process.stdout.isTTY;
     if (this.isInteractive && isTTY) {
       await this.interactiveRun(report);

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -84,8 +84,7 @@ export default class Optimize extends Command {
     this.optimizations = flags.optimization as Optimizations[];
     this.outputMethod = flags.output as Outputs;
 
-    const optimizationsObject = {...this.optimizations};
-    this.metricsMetadata.optimizations = optimizationsObject;
+    this.metricsMetadata.optimizations = JSON.stringify(this.optimizations);
     
     if (!(report.moveToComponents?.length || report.removeComponents?.length || report.reuseComponents?.length)) {
       this.log(`No optimization has been applied since ${this.specFile.getFilePath() ?? this.specFile.getFileURL()} looks optimized!`);

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -84,9 +84,11 @@ export default class Optimize extends Command {
     this.optimizations = flags.optimization as Optimizations[];
     this.outputMethod = flags.output as Outputs;
 
+    this.metricsMetadata.optimized = true;
+
     if (!(report.moveToComponents?.length || report.removeComponents?.length || report.reuseComponents?.length)) {
-      this.metricsMetadata.optimized = false;
       this.log(`No optimization has been applied since ${this.specFile.getFilePath() ?? this.specFile.getFileURL()} looks optimized!`);
+      this.metricsMetadata.optimized = false;
       return;
     }
     
@@ -102,7 +104,6 @@ export default class Optimize extends Command {
         reuseComponents: this.optimizations.includes(Optimizations.REUSE_COMPONENTS)
       }, output: Output.YAML});
 
-      this.metricsMetadata.optimized = true;
       await this.collectMetricsData(report);
 
       const specPath = this.specFile.getFilePath();
@@ -137,8 +138,6 @@ export default class Optimize extends Command {
     if (!elements) {
       return;
     }
-
-    this.metricsMetadata.optimized = true;
 
     for (let i = 0; i < elements.length; i++) {
       const element = elements[+i];

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -84,21 +84,12 @@ export default class Optimize extends Command {
     this.optimizations = flags.optimization as Optimizations[];
     this.outputMethod = flags.output as Outputs;
 
-    this.metricsMetadata.optimized = true;
-
-    if (report.moveToComponents?.length) {
-      this.metricsMetadata.optimization_moveToComponents = true;
-    }
-    if (report.removeComponents?.length) {
-      this.metricsMetadata.optimization_removeComponents = true;
-    }
-    if (report.reuseComponents?.length) {
-      this.metricsMetadata.optimization_reuseComponents = true;
-    }
-
-    if (!(report.moveToComponents?.length || report.removeComponents?.length || report.reuseComponents?.length)) {
-      this.log(`No optimization has been applied since ${this.specFile.getFilePath() ?? this.specFile.getFileURL()} looks optimized!`);
+    if (report.moveToComponents?.length || report.removeComponents?.length || report.reuseComponents?.length) {
+      this.metricsMetadata.optimized = true;
+      await this.collectMetricsData(report);
+    } else {
       this.metricsMetadata.optimized = false;
+      this.log(`No optimization has been applied since ${this.specFile.getFilePath() ?? this.specFile.getFileURL()} looks optimized!`);
       return;
     }
     
@@ -201,5 +192,23 @@ export default class Optimize extends Command {
       choices: [{name: 'log to terminal',value: Outputs.TERMINAL}, {name: 'create new file', value: Outputs.NEW_FILE}, {name: 'update original', value: Outputs.OVERWRITE}]
     }]);
     this.outputMethod = outputRes.output;
+  }
+
+  private async collectMetricsData(report: Report) {
+    try {
+      if (report.moveToComponents?.length) {
+        this.metricsMetadata.optimization_moveToComponents = true;
+      }
+      if (report.removeComponents?.length) {
+        this.metricsMetadata.optimization_removeComponents = true;
+      }
+      if (report.reuseComponents?.length) {
+        this.metricsMetadata.optimization_reuseComponents = true;
+      }    
+    } catch (e: any) {
+      if (e instanceof Error) {
+        this.log(`Skipping submitting anonymous metrics due to the following error: ${e.name}: ${e.message}`);
+      }
+    }
   }
 }


### PR DESCRIPTION
**Description**
Solving issue from `optimize` command when sending data to New Relic servers. 
Basically, `action.finished` metric is not sent to NR servers probably because of the format accepted by New Relic API.